### PR TITLE
Increase visibility of the prerequisites in the getting started doc.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,14 +1,18 @@
 Getting Started with Bazel
 ==========================
 
+Prerequisites
+-------------
+
+Be sure you have installed all of the prerequisites for your platform, as outlined in the [README](install.md).
+
 Setup
 -----
 
 Every Bazel project is contained in a directory called a _build root_,
 which holds the inputs, outputs, and build rules for the project. To create a
 Bazel project, first clone the [Github repo](https://github.com/google/bazel)
-and build Bazel (follow the instructions in the
-[README](install.md) to install prerequisites):
+and build Bazel:
 
 ```bash
 $ git clone https://github.com/google/bazel.git


### PR DESCRIPTION
As it is, it's a bit easy to miss (parenthetical, etc.)
